### PR TITLE
Add bootstrap img class

### DIFF
--- a/Extensions/news/Resources/Private/Templates/Styles/Twb/Partials/General/DummyMedia.html
+++ b/Extensions/news/Resources/Private/Templates/Styles/Twb/Partials/General/DummyMedia.html
@@ -8,7 +8,7 @@
     </f:then>
     <f:else>
         <f:if condition="{settings.list.media.dummyImage}">
-            <f:image class="img-dummy img-responsive" src="{settings.list.media.dummyImage}" title="" alt=""
+            <f:image class="img-dummy img-responsive img-fluid" src="{settings.list.media.dummyImage}" title="" alt=""
                      maxWidth="{settings.list.media.image.maxWidth}"
                      maxHeight="{settings.list.media.image.maxHeight}" />
         </f:if>

--- a/Extensions/news/Resources/Private/Templates/Styles/Twb/Templates/News/Detail.html
+++ b/Extensions/news/Resources/Private/Templates/Styles/Twb/Templates/News/Detail.html
@@ -106,7 +106,7 @@
 </f:section>
 
 <f:section name="inner-content">
-    <n:renderMedia audioClass="audio-wrapper" imgClass="img-responsive" news="{newsItem}" videoClass="video-wrapper">
+    <n:renderMedia audioClass="audio-wrapper" imgClass="img-responsive img-fluid" news="{newsItem}" videoClass="video-wrapper">
         <f:comment>
             ==================================================
             teaser

--- a/Extensions/news/Resources/Public/Scss/general.scss
+++ b/Extensions/news/Resources/Public/Scss/general.scss
@@ -2,7 +2,6 @@
   img {
     display: inline-block;
     width: 100%;
-    height: auto;
   }
 }
 .news-list-view {

--- a/Extensions/tt_address/4.3.0/Resources/Private/Partials/Full.html
+++ b/Extensions/tt_address/4.3.0/Resources/Private/Partials/Full.html
@@ -8,7 +8,7 @@
                 <div class="col-md-3">
                     <figure class="figure">
                         <f:image image="{address.firstImage}" width="600"
-                                 class="figure-img img-fluid img-thumbnail rounded"
+                                 class="figure-img img-responsive img-rounded img-fluid img-thumbnail rounded"
                                  alt="{img.originalResource.alt}"
                                  title="{img.originalResource.title}"
                                  additionalAttributes="{itemprop:'image', loading: 'lazy'}" />

--- a/Extensions/tt_address/Teaser/Resources/Private/Partials/TeaserItem.html
+++ b/Extensions/tt_address/Teaser/Resources/Private/Partials/TeaserItem.html
@@ -40,7 +40,7 @@
                                     -> f:variable(name: 'imageUri')}
                             </f:else>
                         </f:if>
-                        <img loading="lazy" src="{imageUri}"
+                        <img class="img-responsive img-fluid" loading="lazy" src="{imageUri}"
                              title="{address.firstImage.title}" alt="{address.firstImage.properties.alternative}">
                     </picture>
             </div>

--- a/Resources/Private/Partials/ContentElements/Media/Rendering/Image.html
+++ b/Resources/Private/Partials/ContentElements/Media/Rendering/Image.html
@@ -55,6 +55,6 @@
     <f:variable name="finalHeight" value="{bk2k:lastImageInfo(property: 'height')}" />
     {f:variable(name: '_loading', value: 'lazy')}
     {f:variable(name: '_loading', value: settings.gallery.imageLoading) -> f:if(condition: settings.gallery.imageLoading)}
-    <img loading="{_loading}" src="{src}" width="{finalWidth}" height="{finalHeight}" intrinsicsize="{finalWidth}x{finalHeight}" title="{file.properties.title}" alt="{file.properties.alternative}">
+    <img class="img-responsive img-fluid" loading="{_loading}" src="{src}" width="{finalWidth}" height="{finalHeight}" intrinsicsize="{finalWidth}x{finalHeight}" title="{file.properties.title}" alt="{file.properties.alternative}">
 </picture>
 </html>


### PR DESCRIPTION
The class name for images changed in bootstrap 4:
https://getbootstrap.com/docs/4.1/migration/#images
With both classes the tag is compatible with both versions