### PR TITLE
[TASK] Align with new TYPO3 documentation standards (follow-up)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,7 @@
+.. image:: https://poser.pugx.org/buepro/typo3-pizpalue/v/stable.svg
+   :alt: Latest Stable Version
+   :target: https://extensions.typo3.org/extension/pizpalue/
+
 .. image:: https://img.shields.io/badge/TYPO3-11-orange.svg
    :alt: TYPO3 11
    :target: https://get.typo3.org/version/11
@@ -5,6 +9,14 @@
 .. image:: https://img.shields.io/badge/TYPO3-10-orange.svg
    :alt: TYPO3 10
    :target: https://get.typo3.org/version/10
+
+.. image:: https://poser.pugx.org/buepro/typo3-pizpalue/d/total.svg
+   :alt: Total Downloads
+   :target: https://packagist.org/packages/buepro/typo3-pizpalue
+
+.. image:: https://poser.pugx.org/buepro/typo3-pizpalue/d/monthly
+   :alt: Monthly Downloads
+   :target: https://packagist.org/packages/buepro/typo3-pizpalue
 
 .. image:: https://github.com/buepro/typo3-pizpalue/workflows/CI/badge.svg
    :alt: Continuous Integration Status

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,12 @@
 			"role": "Developer"
 		}
 	],
-	"homepage": "https://github.com/buepro/typo3-pizpalue",
+	"homepage": "https://extensions.typo3.org/extension/pizpalue",
+	"support": {
+		"docs": "https://docs.typo3.org/p/buepro/typo3-pizpalue/main/en-us/",
+		"issues": "https://github.com/buepro/typo3-pizpalue/issues",
+		"source": "https://github.com/buepro/typo3-pizpalue"
+	},
 	"require": {
 		"php": ">=7.3.0",
 		"bk2k/bootstrap-package": "~12.0.4",


### PR DESCRIPTION
Added two new commits regarding badges in README and additional sources (TER, repository and docs.typo3.org) in composer.json.

In addition, the [TER homepage](https://extensions.typo3.org/extension/pizpalue) is missing the "Found an issue?" button, which seems to be caused by the empty "Link to issue tracker" field in the TER extension edit form.

Relates: TYPO3-Documentation/T3DocTeam#185